### PR TITLE
Fix hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Welcome to the Official Repository of KDE Connect iOS!**
 
-**TL;DR: Get the public testing version of KDE Connect iOS by opening [this TestFlight link] (https://testflight.apple.com/join/vxCluwBF) on an iOS >= 15 device!**
+**TL;DR: Get the public testing version of KDE Connect iOS by opening [this TestFlight link](https://testflight.apple.com/join/vxCluwBF) on an iOS >= 15 device!**
 
 Please feel free to give feedback/report bugs in the TestFlight version through:
 
@@ -10,7 +10,7 @@ Please feel free to give feedback/report bugs in the TestFlight version through:
 
 - TestFlight's integrated crash feedback system: upon app crashing, an alert will appear asking you if you would like to send the crash data along as feedback.
 
-- [KDE Bugzilla] (https://bugs.kde.org/enter_bug.cgi?product=kdeconnect&component=ios-application).
+- [KDE Bugzilla](https://bugs.kde.org/enter_bug.cgi?product=kdeconnect&component=ios-application).
 
 **Data Disclosure Notice:**
 - If you don't send ANY feedback AND have "Share with App Developers" disabled, the ONLY information that the KDE developers can access about you is the date that you've installed the TestFlight app.
@@ -31,11 +31,11 @@ Please feel free to give feedback/report bugs in the TestFlight version through:
   -- Screen resolution
   -- (For Crash feedback) stack trace leading to crash
    
-- Sending feedback through [KDE Bugzilla] (https://bugs.kde.org/enter_bug.cgi?product=kdeconnect&component=ios-application) lets you manually disclose as much or as little information as you would like, but all information will have to be investigated manually.
+- Sending feedback through [KDE Bugzilla](https://bugs.kde.org/enter_bug.cgi?product=kdeconnect&component=ios-application) lets you manually disclose as much or as little information as you would like, but all information will have to be investigated manually.
 
 **TestFlight version known behavior and problems:**
 
--  iOS is very much designed around foreground interactions. Therefore, background “daemon-style” applications don’t really exist under conventional means, so the behavior where KDE Connect iOS is unresponsive in the background is more or less intended. There are technically some special categories and "hacky" methods to try to get it to run in the background, but in general, there is no intended/by-design method of keeping a "daemon-style" app running forever in the background. For more information, see [this post on the Apple Dev Forums] (https://developers.apple.com/forums/thread/685525).
+-  iOS is very much designed around foreground interactions. Therefore, background “daemon-style” applications don’t really exist under conventional means, so the behavior where KDE Connect iOS is unresponsive in the background is more or less intended. There are technically some special categories and "hacky" methods to try to get it to run in the background, but in general, there is no intended/by-design method of keeping a "daemon-style" app running forever in the background. For more information, see [this post on the Apple Dev Forums](https://developers.apple.com/forums/thread/685525).
 
 - Miscellaneous crashes (under investigation).
 
@@ -47,10 +47,10 @@ Please feel free to give feedback/report bugs in the TestFlight version through:
 
 This project is intended to be the iOS version of the group of applications called KDE Connect, which uses the LAN network to integrate devices together, for information on KDE Connect, check out:
 
-[The KDE Community Wiki] (https://community.kde.org/KDEConnect)
-[The KDE Userbase Wiki] (https://userbase.kde.org/KDEConnect)
+[The KDE Community Wiki](https://community.kde.org/KDEConnect)
+[The KDE Userbase Wiki](https://userbase.kde.org/KDEConnect)
 
-If you would like to talk to the KDE Connect developers & contributors (for questions or if you would like to contribute!), please go to [KDE Connect development Telegram channel] (https://planet.kde.org/t.me/joinchat/AOS6gA37orb2dZCLhqbZjg)
+If you would like to talk to the KDE Connect developers & contributors (for questions or if you would like to contribute!), please go to [KDE Connect development Telegram channel](https://planet.kde.org/t.me/joinchat/AOS6gA37orb2dZCLhqbZjg)
 
 **Plans & To-Dos (great for contributions!):**
 
@@ -74,7 +74,7 @@ If you would like to check out some other posts about KDE Connect iOS, please se
 
 **For a lengthy history of KDE Connect iOS, please take a look at:**
 
-This project is a continuation of KDE Connect 2014, a codebase that stemmed from the Google Summer of Code 2014 program that remained largely untouched since 2014 until getting picked up again by [Inoki] (https://invent.kde.org/wxiao) in 2019, where some tweaks were added to it to support TLS.
+This project is a continuation of KDE Connect 2014, a codebase that stemmed from the Google Summer of Code 2014 program that remained largely untouched since 2014 until getting picked up again by [Inoki](https://invent.kde.org/wxiao) in 2019, where some tweaks were added to it to support TLS.
 
 KDE Connect 2021 was started as a project for Google Summer of Code 2021 by student Lucas Wang. As of mid-August 2021, the app compiles and is able to perform all of the functionalities currently implemented (though there are likely some bugs to be found). Currently, the app is not yet ready for Release distribution as it lacks certain functionalities compared to the other KDE Connect versions that either need to be implemented or are likely unviable to implement due to iOS restrictions.
 


### PR DESCRIPTION
There were a few broken hyperlinks in the readme, due to a space between the `[]` and `()` parts