### PR TITLE
Removed unnecesarry swtich branch

### DIFF
--- a/KDE Connect/KDE Connect/Swift Backend/Backend.swift
+++ b/KDE Connect/KDE Connect/Swift Backend/Backend.swift
@@ -88,7 +88,6 @@ extension Date {
 // Returns the systemName of the type of device
 func getSFSymbolNameFromDeviceType(deviceType: DeviceType) -> String {
     switch (deviceType) {
-        case .Unknown: return "questionmark.square.dashed"
         case .Desktop: return "desktopcomputer"
         case .Laptop: return "laptopcomputer"
         case .Phone: return "apps.iphone"


### PR DESCRIPTION
The unknown branch is not necessary. It returns the same as the default branch. I thought this might improve visibility by reducing code size.
But on the other hand, I understand it it's  debatable, maybe just append a comment on the default branch?:
// Unknown device 
default: return "..."