### PR TITLE
UI:Sort RunCommand is accending order

### DIFF
--- a/KDE Connect/KDE Connect/Plugins and Plugin Views/RunCommand/RunCommand.swift
+++ b/KDE Connect/KDE Connect/Plugins and Plugin Views/RunCommand/RunCommand.swift
@@ -86,7 +86,7 @@ import SwiftUI
     }
     
     private func processCommandsDict(_ commandsDict: CommandsDictionary) -> [CommandEntry] {
-        return commandsDict.compactMap { commandKey, commandInfo in
+        let entries = commandsDict.compactMap { commandKey, commandInfo in
             if let commandName = commandInfo["name"],
                let command = commandInfo["command"] {
                 let commandEntry = CommandEntry(name: commandName, command: command, key: commandKey)
@@ -96,5 +96,6 @@ import SwiftUI
                 return nil
             }
         }
+        return entries.sorted { $0.name == $1.name ? $0.key < $1.key : $0.name < $1.name }
     }
 }


### PR DESCRIPTION
- [x] I understand that GitHub is only a read-only mirror of the KDE project and will instead open a merge request on [KDE's GitLab](https://invent.kde.org/network/kdeconnect-ios)
I have change the run command code so it sort the commands in ascending order, making them easier to find and as the list grows, this change will work on both initial load and after the refresh.