### PR TITLE
Fix Devices help button safe-area placement

### DIFF
--- a/KDE Connect/KDE Connect/Views/Abstracted Views/iOS14Compatibility/View+iOS14Compatibility.swift
+++ b/KDE Connect/KDE Connect/Views/Abstracted Views/iOS14Compatibility/View+iOS14Compatibility.swift
@@ -203,12 +203,16 @@ extension View {
     @ViewBuilder
     func bottomOverlay<Content: View>(@ViewBuilder content: @escaping () -> Content) -> some View {
         if #available(iOS 15, *) {
-            self.overlay(alignment: .bottom, content: content)
-        } else {
-            VStack {
-                Spacer()
+            self.safeAreaInset(edge: .bottom, alignment: .center, spacing: 0) {
                 content()
             }
+        } else {
+            self.overlay(
+                VStack {
+                    Spacer()
+                    content()
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use `safeAreaInset(edge: .bottom)` for bottom overlays on iOS 15 and newer.
- Preserve the iOS 14 compatibility path by applying the fallback as an overlay on the original view.

## Root Cause
The Devices page places the "Can't find your devices here?" control through `bottomOverlay`. On iOS 15+, that helper used a plain bottom overlay, so the tab bar did not reserve layout space and the button could sit behind the bottom toolbar/tab bar.

## Validation
- `xcodebuild -project 'KDE Connect/KDE Connect.xcodeproj' -scheme 'KDE Connect' -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- Launched the app on an iPhone 17 Pro simulator and verified the button renders above the tab bar on the Devices page.